### PR TITLE
Bugfix: crash opening a flowchart from a Dashboard

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,9 +1,14 @@
 =======
 History
 =======
+2024.5.23 -- Bugfix: crash opening a flowchart from a Dashboard
+   * SEAMM could crash when asking the Flowchart Open dialog to get the flowchart from a
+     previous job. This only happened if the Dashboard was known but the stored password
+     was wrong.
+
 2024.4.22 -- Moving user preferences to ~/.seamm.d
-    * Added better output when there are failures in the Dashboard.
-    * To better support Docker, moving ~/.seammrc to ~/.seamm.d/seamrc
+   * Added better output when there are failures in the Dashboard.
+   * To better support Docker, moving ~/.seammrc to ~/.seamm.d/seamrc
 
 2023.11.15 -- Bugfix: boolean options now work
    * Boolean options were not handled correctly when submitting jobs.

--- a/seamm_dashboard_client/dashboard.py
+++ b/seamm_dashboard_client/dashboard.py
@@ -404,7 +404,7 @@ class Dashboard(object):
             response = self._url_get("/api/status")
         except DashboardTimeoutError:
             return "down"
-        except (DashboardConnectionError, DashboardUnknownError):
+        except (DashboardConnectionError, DashboardUnknownError, DashboardLoginError):
             return "error"
 
         if response.status_code != 200:

--- a/seamm_dashboard_client/dashboard.py
+++ b/seamm_dashboard_client/dashboard.py
@@ -20,7 +20,7 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 logger = logging.getLogger(__name__)
 
-logger.setLevel("DEBUG")
+# logger.setLevel("DEBUG")
 
 
 def safe_filename(filename):


### PR DESCRIPTION
   * SEAMM could crash when asking the Flowchart Open dialog to get the flowchart from a
     previous job. This only happened if the Dashboard was known but the stored password
     was wrong.