### PR TITLE
Increased timeout for HTTP requests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.4.3 -- Increased timeout for HTTP requests
+   * Increased the default timout to 5 seconds, and 60 seconds for submitting jobs to
+     allow time to transfer files.
+     
 2024.6.27 -- Added support for using local files in Jobs
 
 2024.5.23 -- Bugfix: crash opening a flowchart from a Dashboard

--- a/seamm_dashboard_client/dashboard.py
+++ b/seamm_dashboard_client/dashboard.py
@@ -73,7 +73,7 @@ class DashboardUnknownError(Exception):
 
 class Dashboard(object):
     def __init__(
-        self, name, url, username=None, password=None, user_agent=None, timeout=1
+        self, name, url, username=None, password=None, user_agent=None, timeout=5
     ):
         """The interface to a Dashboard
 
@@ -549,7 +549,7 @@ class Dashboard(object):
             # Now transfer the files
             for filename, newname in files.items():
                 logger.info(f"   {filename} --> {newname}")
-                result = job.put_file(filename, newname)
+                result = job.put_file(filename, newname, timeout=60)
                 if result is None:
                     logger.warning(
                         f"There was a major error transferring the file {filename} to "
@@ -919,7 +919,7 @@ class _Job(collections.abc.Mapping):
 
         return response.content.decode(encoding="UTF-8")
 
-    def put_file(self, localfile, remotefile):
+    def put_file(self, localfile, remotefile, timeout=60):
         """Put a file to a job.
 
         Parameters
@@ -935,7 +935,7 @@ class _Job(collections.abc.Mapping):
         headers = {"Content-Type": m.content_type}
 
         response = self.dashboard._url_post(
-            f"/api/jobs/{self.id}/files", headers=headers, data=m
+            f"/api/jobs/{self.id}/files", headers=headers, data=m, timeout=timeout
         )
 
         return response


### PR DESCRIPTION
* Increased the default timout to 5 seconds, and 60 seconds for submitting jobs to allow time to transfer files.