### PR TITLE
Bugfix: login() failed against dashboards with no CSRF cookie

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2026.8.8 -- Bugfix: login() failed against dashboards with no CSRF cookie
+   * Dashboard.login() raised DashboardLoginError if a dashboard's login response had no
+     CSRF cookie, even though the login itself succeeded. Some dashboards (e.g. the new
+     seamm_webui) don't use a CSRF cookie at all; a missing one is now treated as
+     "nothing extra to send" rather than a failure.
+
 2025.10.31 -- Improved handling of timeouts
    * Actually increased the default timeouts to 60s.
    * Improved error messages to help diagnose problems with timeouts.

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/seamm_dashboard_client/dashboard.py
+++ b/seamm_dashboard_client/dashboard.py
@@ -163,7 +163,7 @@ class Dashboard(object):
             "description": description,
         }
 
-        response = self._url_post("/api/projects", json=data)
+        response = self._url_post("/api/projects", json_data=data)
 
         if response.status_code != 201:
             raise DashboardUnknownError(
@@ -332,6 +332,15 @@ class Dashboard(object):
                 f"Unknown error with the dashboard '{self.name}': ({type(e)}) {str(e)}",
             )
         else:
+            if self._dump:
+                print("Result from call:")
+                print(f"status = {response.status_code}")
+                print(f"reason = {response.reason}")
+                print("Headers")
+                print(json.dumps({**response.headers}, indent=4))
+                print(f"Text:\n{response.text}")
+                print(20 * "x")
+
             if response.status_code == 400:
                 try:
                     result = response.json()["msg"]
@@ -358,11 +367,14 @@ class Dashboard(object):
                 if "csrf_access_token" in cookies:
                     csrf_token = cookies["csrf_access_token"]
                 else:
-                    raise DashboardLoginError(
-                        url,
-                        f"Could not log in to dashboard {self.name} -- did not get "
-                        "CSRF token",
-                    )
+                    # Not every dashboard uses a CSRF double-submit cookie
+                    # (e.g. seamm_webui deliberately doesn't -- it relies
+                    # on SameSite + CORS instead). The login itself already
+                    # succeeded (200, session cookie set); a missing CSRF
+                    # cookie just means don't send the X-CSRF-TOKEN header,
+                    # not that login failed. _url_get/_url_post already
+                    # treat csrf_token=None as "no header to add".
+                    csrf_token = None
         finally:
             if self._dump:
                 print()
@@ -529,7 +541,7 @@ class Dashboard(object):
             "username": self.username,
         }
 
-        response = self._url_post("/api/jobs", json=data)
+        response = self._url_post("/api/jobs", json_data=data)
 
         if response.status_code != 201:
             raise DashboardSubmitError(
@@ -663,7 +675,7 @@ class Dashboard(object):
 
         return response
 
-    def _url_post(self, url, headers={}, json={}, data=None, timeout=None):
+    def _url_post(self, url, headers={}, json_data={}, data=None, timeout=None):
         """Post to the url, handling errors.
 
         Parameters
@@ -672,7 +684,7 @@ class Dashboard(object):
             The URL to get
         headers : dict
             Dictionary of HTTP headers to sned.
-        json : dict
+        json_data : dict
             A JSON serializable object to send in the body.
         timeout : int
             A custom timeout, defaults to instance value
@@ -700,7 +712,7 @@ class Dashboard(object):
             print(json.dumps(headers, indent=4))
             print()
             print("json:")
-            print(json.dumps(json, indent=4))
+            print(json.dumps(json_data, indent=4))
             print()
             print(20 * "x")
 
@@ -708,7 +720,7 @@ class Dashboard(object):
         try:
             if data is None:
                 response = session.post(
-                    url, json=json, headers=headers, timeout=timeout
+                    url, json=json_data, headers=headers, timeout=timeout
                 )
             else:
                 response = session.post(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -963,3 +963,27 @@ def test_project_jobs():
         print(result)
         print("---")
     assert result == answer
+
+
+@responses.activate
+def test_login_without_csrf_cookie():
+    """Not every dashboard uses a CSRF double-submit cookie -- seamm_webui
+    deliberately doesn't (SameSite + CORS instead, see its auth.py). A
+    successful login response with no CSRF cookie at all must still count
+    as a successful login, just with no X-CSRF-TOKEN header to send
+    afterward, not raise DashboardLoginError.
+    """
+    d = Dashboard("test", test_url, username="psaxe", password="secret")
+
+    responses.add(
+        responses.POST,
+        "http://test/api/auth/token",
+        json={"username": "psaxe"},
+        status=200,
+        # No Set-Cookie header at all -- unlike the old dashboard, which
+        # always sets access/refresh + CSRF cookies together.
+    )
+
+    session, csrf_token = d.login()
+    assert csrf_token is None
+    assert session is not None


### PR DESCRIPTION
* Dashboard.login() raised DashboardLoginError if a dashboard's login response had no
  CSRF cookie, even though the login itself succeeded. Some dashboards (e.g. the new
  seamm_webui) don't use a CSRF cookie at all; a missing one is now treated as
  "nothing extra to send" rather than a failure.