### PR TITLE
Multi-queue job submission, and two real seamm_webui compatibility bugs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,30 @@
 =======
 History
 =======
+2026.8.10 -- Multi-queue job submission, and two real seamm_webui compatibility bugs
+    * ``Dashboard.list_queues()``: lists the queues (clusters, or a plain
+      local target) the dashboard's paired JobServer can route jobs to,
+      with each field's override limits -- empty (not an error) against a
+      dashboard that doesn't support this. ``Dashboard.submit()`` gained
+      ``queue=``/``slurm_overrides=`` keyword arguments to request a
+      specific queue and per-job SLURM resource overrides; omitted
+      entirely from the submitted job's parameters when not given, so
+      existing callers are unaffected.
+    * Bugfix: ``Dashboard.login()`` treated a blank username/password
+      (``""``) differently from not providing one at all (``None``),
+      POSTing empty credentials as if real -- rejected by the dashboard,
+      breaking login against any dashboard running with no authentication
+      required. A blank credential now skips the login attempt entirely,
+      the same as ``None`` already did.
+    * Bugfix: ``Dashboard.list_projects()`` only worked against the old
+      Flask-based dashboard's ``GET /api/projects/list`` endpoint --
+      ``seamm_webui`` has no such route at all and returned an error.
+      Switched to ``GET /api/projects`` (returns full project records
+      instead of bare names) and extracts the names client-side; this
+      endpoint exists, with the same project-name field, on both
+      dashboard implementations, so ``list_projects()`` now works
+      against either without needing to know which one it's talking to.
+
 2026.8.8 -- Bugfix: login() failed against dashboards with no CSRF cookie
    * Dashboard.login() raised DashboardLoginError if a dashboard's login response had no
      CSRF cookie, even though the login itself succeeded. Some dashboards (e.g. the new

--- a/seamm_dashboard_client/dashboard.py
+++ b/seamm_dashboard_client/dashboard.py
@@ -173,13 +173,49 @@ class Dashboard(object):
             )
 
     def list_projects(self):
-        """Get a list of the projects."""
-        response = self._url_get("/api/projects/list")
+        """Get a list of the project names.
+
+        Uses ``GET /api/projects`` (full project objects, ``name`` a
+        required field on both backends -- see the old ``seamm_dashboard``'s
+        ``swagger.yml``) and extracts just the names, rather than the old
+        dashboard-only ``GET /api/projects/list`` (a list of bare name
+        strings) this used to call: ``seamm_webui`` has no such endpoint at
+        all -- hitting it there 422s (FastAPI trying to parse the literal
+        path segment ``"list"`` as an ``/api/projects/{project_id}``
+        integer). This shape works identically against both, so no
+        per-backend branching is needed.
+        """
+        response = self._url_get("/api/projects")
 
         if response.status_code != 200:
             logger.warning(
                 "Encountered an error getting the project list from dashboard "
                 f" '{self.name}', error code: {response.status_code}"
+            )
+            return []
+
+        return [project["name"] for project in response.json()]
+
+    def list_queues(self):
+        """Get the list of queues (cluster/section targets) this
+        dashboard's paired JobServer instance can route jobs to, with the
+        per-field override limits a submission client should render as
+        constrained inputs -- see seamm_jobserver's
+        docs/developer_guide/campaigns/2026-08-10/ (multi-queue routing).
+
+        Empty if the dashboard doesn't support this at all (only
+        seamm_webui implements ``GET /api/queues`` -- an old
+        seamm_dashboard 404s) or has no queues configured there -- both
+        treated as an ordinary case, not an error, since queue routing is
+        an optional, additive feature a caller should just not offer a
+        picker for rather than fail over.
+        """
+        response = self._url_get("/api/queues")
+
+        if response.status_code != 200:
+            logger.debug(
+                f"Dashboard '{self.name}' has no queues available "
+                f"(code={response.status_code}); treating as none configured."
             )
             return []
 
@@ -298,7 +334,15 @@ class Dashboard(object):
         url = self.url + "/api/auth/token"
         session = requests.session()
 
-        if self.username is None or self.password is None:
+        # Treat a blank string the same as None -- not just a defensive
+        # equivalence. seamm/tk_job_handler.py's credential dialog returns
+        # "" (not None) for a field left empty when the user clicks OK,
+        # e.g. against a seamm_webui instance running --auth none, which
+        # needs no real login at all. Without this, an empty-but-not-None
+        # username/password would be POSTed as real credentials and
+        # rejected (no user named ""), raising DashboardLoginError instead
+        # of the no-login-needed path this is clearly asking for.
+        if not self.username or not self.password:
             return session, None
 
         headers = {"User-Agent": self.user_agent}
@@ -435,8 +479,27 @@ class Dashboard(object):
         project="default",
         title="",
         description="",
+        queue=None,
+        slurm_overrides=None,
     ):
-        """Submit the job to the dashboard."""
+        """Submit the job to the dashboard.
+
+        Parameters
+        ----------
+        queue : str or None
+            Which queue (cluster/section) the paired JobServer instance
+            should route this job to -- one of the names ``list_queues()``
+            returns. ``None`` (default) lets the JobServer fall back to its
+            own configured default queue, or run it locally if it has no
+            queue config at all -- see seamm_jobserver's
+            docs/developer_guide/campaigns/2026-08-10/.
+        slurm_overrides : dict or None
+            Per-directive SLURM overrides for this job, e.g.
+            ``{"ntasks": 4, "mem": "40G"}`` -- must be authorized by the
+            chosen queue's ``limits`` (from ``list_queues()``); the
+            JobServer re-validates server-side regardless of what this
+            sends.
+        """
         logger.info(f"Submitting job to {self.name} ({self.url})")
 
         # Check the status of the dashboard
@@ -532,12 +595,18 @@ class Dashboard(object):
                     raise RuntimeError(f"Can't handle file '{uri}'")
 
         # Prepare the data
+        parameters = {"cmdline": cmdline, "control parameters": values}
+        if queue is not None:
+            parameters["queue"] = queue
+        if slurm_overrides:
+            parameters["slurm"] = slurm_overrides
+
         data = {
             "flowchart": flowchart.to_text(),
             "project": project,
             "title": title,
             "description": description,
-            "parameters": {"cmdline": cmdline, "control parameters": values},
+            "parameters": parameters,
             "username": self.username,
         }
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3,6 +3,7 @@
 
 """Tests for `seamm_dashboard_client` package."""
 
+import json
 import re
 
 import pytest  # noqa: F401
@@ -19,6 +20,20 @@ def test_construction():
     """Just create an object and test its type."""
     result = Dashboard("dev", url)
     assert str(type(result)) == "<class 'seamm_dashboard_client.dashboard.Dashboard'>"
+
+
+@responses.activate
+def test_login_blank_credentials_skips_token_post():
+    # seamm/tk_job_handler.py's credential dialog returns "" (not None)
+    # for a field left blank on OK -- must be treated as "no login
+    # needed" (e.g. against a seamm_webui --auth none instance), not
+    # POSTed as real (and rejected) credentials.
+    d = Dashboard("test", test_url, username="", password="")
+
+    session, csrf_token = d.login()
+
+    assert csrf_token is None
+    assert len(responses.calls) == 0  # never POSTed to /api/auth/token at all
 
 
 @responses.activate
@@ -235,13 +250,161 @@ def test_list_projects():
 
         responses.add(
             responses.GET,
-            "http://test/api/projects/list",
-            json=["default", "packmol", "recipes"],
+            "http://test/api/projects",
+            json=[
+                {"id": 1, "name": "default", "path": "/x/default"},
+                {"id": 2, "name": "packmol", "path": "/x/packmol"},
+                {"id": 3, "name": "recipes", "path": "/x/recipes"},
+            ],
             status=200,
         )
 
     result = d.list_projects()
     assert result == ["default", "packmol", "recipes"]
+
+
+@responses.activate
+def test_list_queues():
+    "Test listing the queues (seamm_webui's GET /api/queues)."
+    d = Dashboard("test", test_url)
+
+    responses.add(
+        responses.POST,
+        "https://test/api/auth/token",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "http://test/api/queues",
+        json=[
+            {
+                "name": "local",
+                "type": "local",
+                "default": False,
+                "limits": {},
+            },
+            {
+                "name": "molssi10",
+                "type": "slurm",
+                "default": True,
+                "limits": {
+                    "ntasks": {
+                        "choices": None,
+                        "minimum": "1",
+                        "maximum": "6",
+                        "current": "1",
+                    }
+                },
+            },
+        ],
+        status=200,
+    )
+
+    result = d.list_queues()
+    assert [q["name"] for q in result] == ["local", "molssi10"]
+    assert result[1]["default"] is True
+    assert result[1]["limits"]["ntasks"]["maximum"] == "6"
+
+
+@responses.activate
+def test_list_queues_not_supported_returns_empty_list():
+    "An old seamm_dashboard has no GET /api/queues at all -- treat as none."
+    d = Dashboard("test", test_url)
+
+    responses.add(
+        responses.POST,
+        "https://test/api/auth/token",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "http://test/api/queues",
+        status=404,
+    )
+
+    assert d.list_queues() == []
+
+
+class _FakeStep:
+    step_type = "some-step"
+    data_files = []
+
+
+class _FakeFlowchart:
+    """Duck-types just what Dashboard.submit() actually touches -- no
+    Parameter steps and no data files, so no file-transfer requests are
+    made, keeping this a pure unit test of the parameters payload."""
+
+    def get_nodes(self):
+        return [_FakeStep()]
+
+    def to_text(self):
+        return "flowchart text"
+
+
+@responses.activate
+def test_submit_includes_queue_and_slurm_overrides():
+    d = Dashboard("test", test_url)
+
+    responses.add(
+        responses.POST,
+        "https://test/api/auth/token",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "http://test/api/status",
+        json={"status": "running"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "http://test/api/jobs",
+        json={"id": 42},
+        status=201,
+    )
+
+    d.submit(
+        _FakeFlowchart(),
+        title="a job",
+        queue="molssi10",
+        slurm_overrides={"ntasks": 4},
+    )
+
+    post = [c for c in responses.calls if c.request.url == "http://test/api/jobs"][0]
+    body = json.loads(post.request.body)
+    assert body["parameters"]["queue"] == "molssi10"
+    assert body["parameters"]["slurm"] == {"ntasks": 4}
+
+
+@responses.activate
+def test_submit_omits_queue_and_slurm_when_not_given():
+    d = Dashboard("test", test_url)
+
+    responses.add(
+        responses.POST,
+        "https://test/api/auth/token",
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "http://test/api/status",
+        json={"status": "running"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "http://test/api/jobs",
+        json={"id": 43},
+        status=201,
+    )
+
+    d.submit(_FakeFlowchart(), title="a job")
+
+    post = [c for c in responses.calls if c.request.url == "http://test/api/jobs"][0]
+    body = json.loads(post.request.body)
+    assert "queue" not in body["parameters"]
+    assert "slurm" not in body["parameters"]
 
 
 @responses.activate


### PR DESCRIPTION
* `Dashboard.list_queues()`: lists the queues (clusters, or a plain local target) the dashboard's paired JobServer can route jobs to, with each field's override limits -- empty (not an error) against a dashboard that doesn't support this. `Dashboard.submit()` gained `queue=`/`slurm_overrides=` keyword arguments to request a specific queue and per-job SLURM resource overrides; omitted entirely from the submitted job's parameters when not given, so existing callers are unaffected.
* Bugfix: `Dashboard.login()` treated a blank username/password (`""`) differently from not providing one at all (`None`), POSTing empty credentials as if real -- rejected by the dashboard, breaking login against any dashboard running with no authentication required. A blank credential now skips the login attempt entirely, the same as `None` already did.
* Bugfix: `Dashboard.list_projects()` only worked against the old Flask-based dashboard's `GET /api/projects/list` endpoint -- `seamm_webui` has no such route at all and returned an error (422). Switched to `GET /api/projects` (full project records instead of bare names) and extracts the names client-side; this endpoint exists, with the same project-name field, on both dashboard implementations, so `list_projects()` now works against either without needing to know which one it's talking to.

Real, unmocked validation: all three changes confirmed live against a real `seamm_webui` dev instance and the real Tk desktop client -- jobs actually submitted to both a local queue and a real MolSSI10 SLURM queue this way.